### PR TITLE
fix startup if no config files present and rf2 location not detected

### DIFF
--- a/data/rFactoryConfig.py
+++ b/data/rFactoryConfig.py
@@ -5,19 +5,123 @@ Some can be edited to change how rFactory works, e.g. the car table columns.
 """
 import json
 import os
+from pathlib import Path
 
+from lib.steam_utils import SteamApps
 from data.utils import readFile, writeFile
 
 
-def getKey(config_filename, keyname):
+def getKey(config_filename_arg, keyname):
     """ Error trap when reading config file keys """
     try:
         return config[keyname]
     except Exception as e:
         print(
             'Config file "%s" has no entry for "%s"' %
-            (config_filename, e.args[0]))
+            (config_filename_arg, e.args[0]))
         return '"No such key %s"' % e.args[0]
+
+
+def validate():
+    """
+    Check that the paths have the expected files. Some are optional
+    """
+    paths = dict()
+    paths['rF2root'] = os.path.isdir(rF2root)
+    paths['SteamExe'] = os.path.isfile(SteamExe)
+    paths['DiscordExe'] = os.path.isfile(DiscordExe)
+    paths['CrewChiefExe'] = os.path.isfile(CrewChiefExe)
+    paths['VolumeControlExe'] = os.path.isfile(VolumeControlExe)
+    paths['TeamSpeakExe'] = os.path.isfile(TeamSpeakExe)
+
+    paths['playerPath'] = os.path.isdir(playerPath)
+    # Check rF2 install a little further
+    _vehicles = os.path.join(rF2root, 'Installed', 'Vehicles')
+    paths['vehicles'] = os.path.isdir(_vehicles)
+
+    return paths
+
+
+def auto_detect_apps() -> dict:
+    """ Add auto-detection of some App locations if necessary """
+    auto_conf = {
+        'rF2root': '%ProgramFiles(x86)%/Steam/steamapps/common/rFactor 2',
+        'SteamExe': "%ProgramFiles(x86)%/Steam/steam.exe",
+        'CrewChiefExe': "%ProgramFiles(x86)%/Britton IT Ltd/CrewChiefV4/CrewChiefV4.exe",
+        }
+    # Test if any of the above entries do not exist
+    auto_detect_needed = [True for key, loc in auto_conf.items() if not os.path.exists(os.path.expandvars(loc))]
+
+    if not auto_detect_needed:
+        return dict()
+
+    # -- Read Steam library
+    steam_apps = SteamApps()
+    auto_conf_result = dict()
+
+    # -- Update auto_conf with auto detected values
+    for key, loc in auto_conf.items():
+        if os.path.exists(os.path.expandvars(loc)):
+            continue
+
+        # -- rFactor 2 steam install detect
+        if key == 'rF2root':
+            rfactor_installdir = steam_apps.find_game_location(app_name="rFactor 2")
+            if rfactor_installdir.exists():
+                auto_conf_result[key] = rfactor_installdir.as_posix()
+        # -- Steam install detect
+        if key == 'SteamExe':
+            steam_dir = Path(steam_apps.find_steam_location() or 'None')
+            if steam_dir.exists():
+                auto_conf_result[key] = Path(steam_dir / 'steam.exe').as_posix()
+        # -- Crew Chief detect
+        if key == 'CrewChiefExe':
+            crew_chief_app = steam_apps.known_apps.get("CrewChiefV4")
+            if not crew_chief_app:
+                continue
+            auto_conf_result[key] = Path(Path(crew_chief_app.get('path')) / crew_chief_app.get('executable')).as_posix()
+
+    return auto_conf_result
+
+
+def new_config_file():
+    """ Make sure we have a fresh config by deleting any existing one """
+    if os.path.exists(config_filename):
+        os.remove(config_filename)
+
+    config = {
+        # rF2 items
+        '# %ProgramFiles(x86)% will be expanded to your Windows setting but you can write it explicitly if you want': "",
+        '# Same for %LOCALAPPDATA%': "",
+        '# Use / not backslash': "",
+        'rF2root': '%ProgramFiles(x86)%/Steam/steamapps/common/rFactor 2',
+        'SteamExe': "%ProgramFiles(x86)%/Steam/steam.exe",
+        'SteamDelaySeconds': 10,
+        '#SteamDelaySeconds: How long it takes Steam to start up before we can start rF2': "",
+        # 'DiscordExe' : '"%APPDATA%/Microsoft/Windows/Start Menu/Programs/Discord Inc/Discord.lnk"',
+        # '#DiscordExe: had to use short cut as the command wouldn\'t work' : '',
+        'DiscordExe': '%LOCALAPPDATA%/Discord/Update.exe',
+        'DiscordArgs': '--processStart Discord.exe',
+        'CrewChiefExe': "%ProgramFiles(x86)%/Britton IT Ltd/CrewChiefV4/CrewChiefV4.exe",
+        'CrewChiefArgs': 'RF2_64BIT',
+        'VolumeControlExe': "%ProgramFiles(x86)%/VolumeControl/VolumeControl.exe",
+        'TeamSpeakExe': "%ProgramFiles(x86)%/TeamSpeak 3 Client/ts3client_win64.exe",
+        '#MyPreCommand: use this call a program or batch file before rF2 runs': "",
+        'MyPreCommand': '',
+        'MyPreCommandArgs': '',
+        '#MyPostCommand: use this call a program or batch file after rF2 runs': "",
+        'MyPostCommand': '',
+        'MyPostCommandArgs': '',
+        'UserData player': 'player'
+    }
+
+    # -- Add auto detected items
+    config.update(auto_detect_apps())
+
+    _text = json.dumps(config, sort_keys=True, indent=4)
+    writeFile(config_filename, _text)
+    return config
+
 
 # General items
 
@@ -207,56 +311,3 @@ SteamDelayS = getKey(config_filename, 'SteamDelaySeconds')
 
 player = getKey(config_filename, 'UserData player')
 playerPath = os.path.join(rF2root, 'UserData', player)
-
-
-def validate():
-    """
-    Check that the paths have the expected files. Some are optional
-    """
-    paths = dict()
-    paths['rF2root'] = os.path.isdir(rF2root)
-    paths['SteamExe'] = os.path.isfile(SteamExe)
-    paths['DiscordExe'] = os.path.isfile(DiscordExe)
-    paths['CrewChiefExe'] = os.path.isfile(CrewChiefExe)
-    paths['VolumeControlExe'] = os.path.isfile(VolumeControlExe)
-    paths['TeamSpeakExe'] = os.path.isfile(TeamSpeakExe)
-
-    paths['playerPath'] = os.path.isdir(playerPath)
-    # Check rF2 install a little further
-    _vehicles = os.path.join(rF2root, 'Installed', 'Vehicles')
-    paths['vehicles'] = os.path.isdir(_vehicles)
-
-    return paths
-
-
-def new_config_file():
-    """ Make sure we have a fresh config by deleting any existing one """
-    os.remove(config_filename)
-    config = {
-        # rF2 items
-        '# %ProgramFiles(x86)% will be expanded to your Windows setting but you can write it explicitly if you want': "",
-        '# Same for %LOCALAPPDATA%': "",
-        '# Use / not backslash': "",
-        'rF2root': '%ProgramFiles(x86)%/Steam/steamapps/common/rFactor 2',
-        'SteamExe': "%ProgramFiles(x86)%/Steam/steam.exe",
-        'SteamDelaySeconds': 10,
-        '#SteamDelaySeconds: How long it takes Steam to start up before we can start rF2': "",
-        # 'DiscordExe' : '"%APPDATA%/Microsoft/Windows/Start Menu/Programs/Discord Inc/Discord.lnk"',
-        # '#DiscordExe: had to use short cut as the command wouldn\'t work' : '',
-        'DiscordExe': '%LOCALAPPDATA%/Discord/Update.exe',
-        'DiscordArgs': '--processStart Discord.exe',
-        'CrewChiefExe': "%ProgramFiles(x86)%/Britton IT Ltd/CrewChiefV4/CrewChiefV4.exe",
-        'CrewChiefArgs': 'RF2_64BIT',
-        'VolumeControlExe': "%ProgramFiles(x86)%/VolumeControl/VolumeControl.exe",
-        'TeamSpeakExe': "%ProgramFiles(x86)%/TeamSpeak 3 Client/ts3client_win64.exe",
-        '#MyPreCommand: use this call a program or batch file before rF2 runs': "",
-        'MyPreCommand': '',
-        'MyPreCommandArgs': '',
-        '#MyPostCommand: use this call a program or batch file after rF2 runs': "",
-        'MyPostCommand': '',
-        'MyPostCommandArgs': '',
-        'UserData player': 'player'
-    }
-    _text = json.dumps(config, sort_keys=True, indent=4)
-    writeFile(config_filename, _text)
-    return config

--- a/lib/acf.py
+++ b/lib/acf.py
@@ -1,0 +1,139 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2016 Leonid Runyshkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+SECTION_START = '{'
+SECTION_END = '}'
+
+
+def loads(data, wrapper=dict):
+    """
+    Loads ACF content into a Python object.
+    :param data: An UTF-8 encoded content of an ACF file.
+    :param wrapper: A wrapping object for key-value pairs.
+    :return: An Ordered Dictionary with ACF data.
+    """
+    if not isinstance(data, str):
+        raise TypeError('can only load a str as an ACF but got ' + type(data).__name__)
+
+    parsed = wrapper()
+    current_section = parsed
+    sections = []
+
+    lines = (line.strip() for line in data.splitlines())
+
+    for line in lines:
+        try:
+            key, value = line.split(None, 1)
+            key = key.replace('"', '').lstrip()
+            value = value.replace('"', '').rstrip()
+        except ValueError:
+            if line == SECTION_START:
+                # Initialize the last added section.
+                current_section = _prepare_subsection(parsed, sections, wrapper)
+            elif line == SECTION_END:
+                # Remove the last section from the queue.
+                sections.pop()
+            else:
+                # Add a new section to the queue.
+                sections.append(line.replace('"', ''))
+            continue
+
+        current_section[key] = value
+
+    return parsed
+
+
+def load(fp, wrapper=dict):
+    """
+    Loads the contents of an ACF file into a Python object.
+    :param fp: A file object.
+    :param wrapper: A wrapping object for key-value pairs.
+    :return: An Ordered Dictionary with ACF data.
+    """
+    return loads(fp.read(), wrapper=wrapper)
+
+
+def dumps(obj):
+    """
+    Serializes a dictionary into ACF data.
+    :param obj: A dictionary to serialize.
+    :return: ACF data.
+    """
+    if not isinstance(obj, dict):
+        raise TypeError('can only dump a dictionary as an ACF but got ' + type(obj).__name__)
+
+    return '\n'.join(_dumps(obj, level=0)) + '\n'
+
+
+def dump(obj, fp):
+    """
+    Serializes a dictionary into ACF data and writes it to a file.
+    :param obj: A dictionary to serialize.
+    :param fp: A file object.
+    """
+    fp.write(dumps(obj))
+
+
+def _dumps(obj, level):
+    """
+    Does the actual serializing of data into an ACF format.
+    :param obj: A dictionary to serialize.
+    :param level: Nesting level.
+    :return: A List of strings.
+    """
+    lines = []
+    indent = '\t' * level
+
+    for key, value in obj.items():
+        if isinstance(value, dict):
+            # [INDENT]"KEY"
+            # [INDENT]{
+            line = indent + '"{}"\n'.format(key) + indent + '{'
+            lines.append(line)
+            # Increase intendation of the nested dict
+            lines.extend(_dumps(value, level + 1))
+            # [INDENT]}
+            lines.append(indent + '}')
+        else:
+            # [INDENT]"KEY"[TAB][TAB]"VALUE"
+            lines.append(indent + '"{}"'.format(key) + '\t\t' + '"{}"'.format(value))
+
+    return lines
+
+
+def _prepare_subsection(data, sections, wrapper):
+    """
+    Creates a subsection ready to be filled.
+    :param data: Semi-parsed dictionary.
+    :param sections: A list of sections.
+    :param wrapper: A wrapping object for key-value pairs.
+    :return: A newly created subsection.
+    """
+    current = data
+    for i in sections[:-1]:
+        current = current[i]
+
+    current[sections[-1]] = wrapper()
+    return current[sections[-1]]

--- a/lib/steam_utils.py
+++ b/lib/steam_utils.py
@@ -1,0 +1,242 @@
+"""
+    Utilities to read Valve's Steam Library on a Windows Machine
+
+    from https://github.com/tappi287/simmon_gui/blob/master/modules/steam_utils.py
+    MIT licensed
+
+    Example usage:
+        # -- This will read the entire steam library aka every app_manifest file.
+        #    With around 150 games installed on an SATA SSD this shouldn't take longer than
+        #    half a second.
+        steam_apps = SteamApps()
+        rfactor_app = steam_apps.known_apps.get('365960', dict())  # 365960 is rF2 app id, dict() is just a fallback
+
+        if not rfactor_app:
+            # We didn't find steam and/or rFactor2
+            return
+
+        # -- rF2 installation directory (absolute, forward slash formatted by pathlib)
+        rfactor_installdir: str = rfactor_app.get('installdir')
+        # -- OR without knowing the App ID --
+        rfactor_installdir: str = steam_apps.find_game_location(app_name="rFactor 2")
+
+        # -- backslash formatted absolute Windows path, just in case you need it for eg. CMD/Batch files
+        from pathlib import WindowsPath
+        str(WindowsPath(rfactor_installdir))
+
+        # -- rF2 absolute path to executable
+        from pathlib import Path
+        rfactor_exe = Path(rfactor_app.get('path')) / rfactor_app.get('executable')
+
+        # os.path can handle Path objects - so no need to convert objects
+        # but eg. open() sometimes doesn't like Path objects so you should Path().as_posix()
+        # which will represent the Path object as forward slashed string.
+"""
+import sys
+import os
+import json
+import logging
+import winreg as registry
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from . import acf
+
+BASE_PATH = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__ + '/..')))
+
+# App this is taken from has json data file "known_apps" that contains definition of known
+# Steam apps. All it really contains is the location of the executable eg:
+# for rf2 this is Bin64/rFactor2.exe
+# I've not yet found the Steam Magic to locate the executables/entry point for installed
+# Steam apps.
+KNOWN_APPS_FILE_CONTENT = '''
+{
+  "365960": {
+    "name": "rFactor 2",
+    "installdir": "rFactor 2",
+    "executable": "rFactor2.exe",
+    "exe_sub_path": "Bin64/"
+  },
+  "CrewChiefV4": {
+    "name": "CrewChief v4",
+    "installdir": "",
+    "executable": "CrewChiefV4.exe",
+    "exe_sub_path": "",
+    "simmon_method": "find_by_registry_keys",
+    "simmon_method_args": [["SOFTWARE\\WOW6432Node\\Britton IT Ltd\\InstalledProducts\\CrewChiefV4",
+      "SOFTWARE\\Britton IT Ltd\\InstalledProducts\\CrewChiefV4"], "InstallLocation"]
+  }
+}
+'''
+# Example of an App that can be located by it's registry keys
+# see class KnownAppsMethods
+KNOWN_APP_CREW_CHIEF_EXAMPLE = '''
+{
+  "CrewChiefV4": {
+    "name": "CrewChief v4",
+    "installdir": "",
+    "executable": "CrewChiefV4.exe",
+    "exe_sub_path": "",
+    "simmon_method": "find_by_registry_keys",
+    "simmon_method_args": [["SOFTWARE\\WOW6432Node\\Britton IT Ltd\\InstalledProducts\\CrewChiefV4",
+      "SOFTWARE\\Britton IT Ltd\\InstalledProducts\\CrewChiefV4"], "InstallLocation"]
+  }
+}
+'''
+STEAM_LIBRARY_FOLDERS = 'LibraryFolders'
+STEAM_LIBRARY_FILE = 'libraryfolders.vdf'
+STEAM_APPS_FOLDER = 'steamapps'
+STEAM_APPS_INSTALL_FOLDER = 'common'
+
+
+class SteamApps:
+    def __init__(self):
+        self.steam_apps, self.known_apps = self.find_installed_steam_games()
+        self.steam_app_names = {m.get('name'): app_id for app_id, m in self.steam_apps.items() if isinstance(m, dict)}
+
+    def find_game_location(self, app_id: int = 0, app_name: str = '') -> Optional[Path]:
+        """ Shorthand method to search installed apps via either id or name """
+        if app_name:
+            name_hits = [n for n in self.steam_app_names.keys() if n.startswith(app_name)]
+            if name_hits:
+                app_id = self.steam_app_names.get(name_hits[0])
+
+        if app_id is None or app_id == 0:
+            return
+
+        m = self.steam_apps.get(app_id)
+
+        for lib_folder in self.steam_apps.get(STEAM_LIBRARY_FOLDERS, list()):
+            app_folder = lib_folder / STEAM_APPS_INSTALL_FOLDER / m.get('installdir')
+
+            if app_folder.exists():
+                return app_folder
+
+    @staticmethod
+    def find_steam_location() -> Optional[str]:
+        try:
+            key = registry.OpenKey(registry.HKEY_CURRENT_USER, "Software\Valve\Steam")
+        except FileNotFoundError as e:
+            logging.error(e)
+            return None
+
+        return registry.QueryValueEx(key, "SteamPath")[0]
+
+    @classmethod
+    def find_steam_libraries(cls) -> Optional[List[Path]]:
+        """ Return Steam Library Path's as pathlib.Path objects """
+        steam_apps_dir = Path(cls.find_steam_location()) / STEAM_APPS_FOLDER
+        steam_lib_file = steam_apps_dir / STEAM_LIBRARY_FILE
+        if not steam_lib_file.exists():
+            return [steam_apps_dir]
+
+        lib_data, lib_folders = dict(), [steam_apps_dir]
+        try:
+            with open(steam_lib_file.as_posix(), 'r') as f:
+                lib_data = acf.load(f)
+        except Exception as e:
+            logging.error(f'Could not read Steam Library {steam_lib_file.name} file: {e}')
+
+        for k, v in lib_data.get(STEAM_LIBRARY_FOLDERS, dict()).items():
+            if isinstance(k, str) and k.isdigit():
+                lib_dir = Path(v) / STEAM_APPS_FOLDER
+                if lib_dir.exists():
+                    lib_folders.append(lib_dir)
+
+        return lib_folders
+
+    @staticmethod
+    def _add_path(manifest: dict, lib_folders):
+        """ Create an 'path' key with an absolute path to the installation directory """
+        p = manifest.get('installdir')
+        for lib_folder in lib_folders:
+            if not p:
+                break
+            abs_p = lib_folder / STEAM_APPS_INSTALL_FOLDER / p
+            if not abs_p.exists():
+                continue
+
+            manifest['installdir'] = abs_p.as_posix()
+
+            # Update absolute path to executable
+            if manifest.get('exe_sub_path'):
+                # Remove potential leading slashes
+                if manifest['exe_sub_path'][0] in ('/', '\\'):
+                    manifest['exe_sub_path'] = manifest['exe_sub_path'][1:]
+                manifest['path'] = Path(abs_p / manifest['exe_sub_path']).as_posix()
+            else:
+                manifest['path'] = abs_p.as_posix()
+
+    def find_installed_steam_games(self) -> Tuple[dict, dict]:
+        steam_apps, known_apps = dict(), dict()
+        lib_folders = self.find_steam_libraries()
+        if not lib_folders:
+            return steam_apps, known_apps
+
+        for lib in lib_folders:
+            for manifest_file in lib.glob('appmanifest*.acf'):
+                try:
+                    with open(manifest_file.as_posix(), 'r') as f:
+                        manifest = acf.load(f)
+                        if manifest is not None:
+                            manifest = manifest.get('AppState')
+                            steam_apps[manifest.get('appid')] = manifest
+                            self._add_path(manifest, lib_folders)
+                except Exception as e:
+                    logging.error('Error reading Steam App manifest: %s %s', manifest_file, e)
+
+        # -- Update entries where we exactly know the path to the executable
+        try:
+            known_apps = json.loads(KNOWN_APPS_FILE_CONTENT)
+        except Exception as e:
+            logging.error('Error reading known apps: %s', e)
+
+        for app_id, entry_dict in known_apps.items():
+            if app_id in steam_apps:
+                known_apps[app_id].update(steam_apps[app_id])
+
+            # -- Get install dir with special method for eg. CrewChief non steam app
+            if 'simmon_method' in entry_dict.keys():
+                method = getattr(KnownAppsMethods, entry_dict.get('simmon_method'))
+                args = entry_dict.get('simmon_method_args')
+
+                if callable(method):
+                    entry_dict['installdir'] = method(*args)
+                    if entry_dict['installdir'] is not None:
+                        entry_dict['path'] = Path(Path(entry_dict['installdir']) /
+                                                  entry_dict['exe_sub_path']).as_posix()
+                    else:
+                        entry_dict['path'] = ''
+
+            # -- Update install dir to an absolute path if not already absolute
+            self._add_path(entry_dict, lib_folders)
+
+        steam_apps[STEAM_LIBRARY_FOLDERS] = lib_folders
+        return steam_apps, known_apps
+
+
+class KnownAppsMethods:
+    @classmethod
+    def find_by_registry_keys_current_user(cls, *args):
+        return cls.find_by_registry_keys(*args, user_reg=True)
+
+    @staticmethod
+    def find_by_registry_keys(keys: Iterable, key_name: str, user_reg: bool = False) -> Optional[str]:
+        key = None
+        reg = registry.HKEY_CURRENT_USER if user_reg else registry.HKEY_LOCAL_MACHINE
+
+        for key_url in keys:
+            try:
+                key = registry.OpenKey(reg, key_url)
+                break
+            except FileNotFoundError as e:
+                logging.error('Could not locate registry key %s: %s', key_url, e)
+
+        if not key:
+            return None
+
+        try:
+            value = registry.QueryValueEx(key, key_name)[0]
+            return value
+        except FileNotFoundError as e:
+            logging.error('Could not locate value in key %s: %s', key_name, e)

--- a/tabCar.py
+++ b/tabCar.py
@@ -68,7 +68,8 @@ class Tab:
         # Initial dummy filter to load data into table
         self.o_filter.filterUpdate(None)
 
-        self.mc.select_row(0)
+        if self.mc.number_of_rows:
+            self.mc.select_row(0)
 
     def getSettings(self):
         """ Return the settings for this tab """

--- a/tabOpponents.py
+++ b/tabOpponents.py
@@ -66,7 +66,8 @@ class Tab:
         # Initial dummy filter to load data into table
         self.o_filter.filterUpdate(None)
 
-        self.mc.select_row(0)
+        if self.mc.number_of_rows:
+            self.mc.select_row(0)
 
     def getSettings(self):
         """ Return the settings for this tab """

--- a/tabTrack.py
+++ b/tabTrack.py
@@ -70,7 +70,8 @@ class Tab:
         # Initial dummy filter to load data into table
         self.o_filter.filterUpdate(None)
 
-        self.mc.select_row(0)
+        if self.mc.number_of_rows:
+            self.mc.select_row(0)
 
     def getSettings(self):
         """ Return the settings for this tab """


### PR DESCRIPTION
Added fixes if rFactory is run for the first time on a system.
Move new_config_file method in data/rFactoryConfig to start of file so it can be found. Also let the tabWidgets not try to select rows if there are no rows to select(case when no rF2 install found).

Also added methods to auto detect install locations of Steam/rF2/CrewChief if not at their default locations.